### PR TITLE
Added missing $ in topic for MQTT PUBLISH messages

### DIFF
--- a/src/mgos_azure_shadow.c
+++ b/src/mgos_azure_shadow.c
@@ -35,7 +35,7 @@
 #define AZURE_TWIN_DELTA_TOPIC "$iothub/twin/PATCH/properties/desired/"
 #define AZURE_TWIN_GET_TOPIC "$iothub/twin/GET/?$rid=get%u"
 #define AZURE_TWIN_UPDATE_TOPIC \
-  "$iothub/twin/PATCH/properties/reported/?rid=upd%u"
+  "$iothub/twin/PATCH/properties/reported/?$rid=upd%u"
 
 struct azure_shadow_update {
   struct mbuf data;


### PR DESCRIPTION
While until now the Azure IoT Hub Gateway v1 accepted this typo (the missing dollar sign), the Gateway v2 will simply close the MQTT connection when receiving a topic without the `$` before `rid`. Microsoft is gradually upgrading existing IoT Hubs to Gateway v2 and there seems to be nothing the customer can do about it. Whether the IoT Hub is already upgraded to Gateway v2 can be seen in the "Properties" tab of the IoT Hub. If it was already upgraded, the "Features" will contain `GWV2`. We are in contact with Microsoft but don't know yet if they will continue to support the broken topic this library is currently sending.

Therefore I think it's important this will be fixed as soon as possible, as devices running the current library version will not be able to connect once the IoT Hub is updated to v2.